### PR TITLE
Added f5-ansible-guardian as a repo to automatically download

### DIFF
--- a/images/ansible/fs/etc/snopsrepo.d/ansible.json
+++ b/images/ansible/fs/etc/snopsrepo.d/ansible.json
@@ -18,6 +18,23 @@
 			],
 			"skip":false,
 			"skipinstall":false
+		},
+		{
+			"name":"f5-ansible-guardian",
+			"repo":"https://github.com/f5devcentral/f5-ansible-guardian.git",
+			"branch":"master",
+			"docs": [
+				{
+					"name":"README.md",
+					"url":"https://github.com/f5devcentral/f5-ansible-guardian/blob/master/README.md"
+				}
+			],
+			"install": [
+				"#!/bin/bash",
+				"cd docs"
+			],
+			"skip":false,
+			"skipinstall":false
 		}
 	]
 }


### PR DESCRIPTION
Hey @0xHiteshPatel I added the Ansible-mvp code named "guardian" to the list of repositories to download. One thing I didn't grok in the ansible.repos config file was the "install" section. I currently have it no-op and cd into docs and that is it. If there is a better way to handle this. Please do let me know. Thanks so much!
-Tom